### PR TITLE
db(postgres): use prepared statements and unify parameter handling; l…

### DIFF
--- a/src/services/orders/CMakeLists.txt
+++ b/src/services/orders/CMakeLists.txt
@@ -13,6 +13,7 @@ project(OrdersService VERSION 1.0.0 LANGUAGES CXX)
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(LIBPQXX REQUIRED libpqxx)
 pkg_check_modules(JSONCPP REQUIRED jsoncpp)
+pkg_check_modules(LIBPQ REQUIRED libpq)
 
 # Include directories
 include_directories(${LIBPQXX_INCLUDE_DIRS})
@@ -20,6 +21,8 @@ include_directories(${JSONCPP_INCLUDE_DIRS})
 include_directories(../../../third_party/valijson/include)
 include_directories(/usr/include/rapidjson)
 include_directories(../../shared)  # Add shared directory to include path
+# Optionally include libpq headers (not usually needed)
+# include_directories(${LIBPQ_INCLUDE_DIRS})
 
 # Add executable
 # Create standalone orders service executable (updated with new architecture)
@@ -45,6 +48,7 @@ set_target_properties(orders_service PROPERTIES
 target_link_libraries(orders_service
   ${JSONCPP_LIBRARIES}
   ${LIBPQXX_LIBRARIES}
+  ${LIBPQ_LIBRARIES}
 )
 
 # Install target

--- a/src/services/users/CMakeLists.txt
+++ b/src/services/users/CMakeLists.txt
@@ -15,6 +15,7 @@ pkg_check_modules(LIBPQXX REQUIRED libpqxx)
 
 # Find jsoncpp via pkg-config
 pkg_check_modules(JSONCPP REQUIRED jsoncpp)
+pkg_check_modules(LIBPQ REQUIRED libpq)
 
 # Include directories
 include_directories(${LIBPQXX_INCLUDE_DIRS})
@@ -22,6 +23,8 @@ include_directories(${JSONCPP_INCLUDE_DIRS})
 include_directories(../../../third_party/valijson/include)
 include_directories(/usr/include/rapidjson)
 include_directories(../../shared) # Add shared directory to include path
+# Optionally include libpq headers (not usually needed)
+# include_directories(${LIBPQ_INCLUDE_DIRS})
 
 # Add executable
 add_executable(users_service
@@ -40,6 +43,7 @@ add_executable(users_service
 # Link libraries
 target_link_libraries(users_service
   ${LIBPQXX_LIBRARIES}
+  ${LIBPQ_LIBRARIES}
   ${JSONCPP_LIBRARIES}
 )
 


### PR DESCRIPTION
…ink libpq in services

- Add exec_prepared_helper<T> to centralize expanding parameter sets and invoking prepared statements.
- Replace ad-hoc arity-specific exec_params calls with consistent prepare + exec flow in execQuery, execCommand and execBatch.
- Generate deterministic statement names to reuse prepared statements per query/command.
- Add pkg_check_modules(LIBPQ) and ${LIBPQ_LIBRARIES} to users and orders CMakeLists; keep optional include_directories(${LIBPQ_INCLUDE_DIRS}) commented for clarity.